### PR TITLE
OpenGL-dockerization and JSON-logs through x3d-capture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+#FROM debian:buster
+FROM ubuntu:focal
+EXPOSE 1234
+EXPOSE 42000
+EXPOSE 42001
+EXPOSE 42002
+EXPOSE 42003
+VOLUME /out
+RUN apt-get update && apt-get -y upgrade && DEBIAN_FRONTEND=noninteractive apt-get -y install wget gdebi-core xvfb supervisor ffmpeg x264 aria2 xserver-xorg-video-all mesa-utils tigervnc-standalone-server python3 python3-pip xdotool && pip3 install websockets
+RUN aria2c -x 16 https://github.com/cyberbotics/webots/releases/download/R2020b-rev1/webots_2020b-rev1_amd64.deb
+RUN gdebi -n webots_2020b-rev1_amd64.deb && rm webots_2020b-rev1_amd64.deb
+COPY . /app
+ENTRYPOINT /app/supervisor.sh

--- a/capture-x3d.py
+++ b/capture-x3d.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import asyncio
+import websockets
+import time
+
+async def get_x3d():
+  uri = "ws://localhost:1234/"
+  async with websockets.connect(uri) as websocket:
+    await websocket.send("x3d;broadcast")
+    while True:
+      x3d_line = await websocket.recv()
+      print(x3d_line)
+
+if __name__ == "__main__":
+  while True:
+    try:
+      asyncio.get_event_loop().run_until_complete(get_x3d())
+    except:
+      time.sleep(0.1)

--- a/capture_x3d.sh
+++ b/capture_x3d.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/python3 /app/capture-x3d.py > /out/x3d_capture

--- a/disable_viewport.sh
+++ b/disable_viewport.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sleep 5 && xdotool key ctrl+b

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  webots-game:
+    build: .
+    privileged: true
+    volumes:
+      - ../webots_video_out/:/out
+    shm_size: '4gb'
+    ports:
+      - 1234:1234
+    devices:
+      - "/dev/dri:/dev/dri"

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,0 +1,30 @@
+[supervisord]
+logfile=/out/supervisord.log
+
+
+[program:xvfb]
+command=/usr/bin/Xvfb :1 +iglx -s 6000 -screen scrn 1920x1200x24+32 -shmem
+redirect_stderr=true
+redirect_stdout=true
+priority=100
+
+#[program:ffmpeg_screenrec]
+#command=/usr/bin/ffmpeg -video_size 1920x1200 -framerate 60 -f x11grab -i :1.0+0,0 -c:v libx264 -crf 0 -preset ultrafast /out/output.mkv
+#priority=200
+
+[program:capture_x3d]
+command=/app/capture_x3d.sh
+priority=250
+
+[program:webots]
+environment=DISPLAY=":1"
+command=/usr/local/bin/webots --no-sandbox --batch --mode=fast --stream="port=1234;mode=x3d;monitorActivity" --fullscreen /app/worlds/soccer.wbt
+priority=300
+redirect_stderr=true
+redirect_stdout=true
+
+# evil hack, doesn't even work (yet)
+#[program:disable_rendering]
+#environment=DISPLAY=":1"
+#command=/app/disable_viewport.sh
+#priority=350

--- a/supervisor.sh
+++ b/supervisor.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+supervisord -nc /app/supervisor.conf


### PR DESCRIPTION
I cannot get headless OpenGL to work for the life of me but I do get a full copy of all movements in the game as an x3d-stream by dumping the websocket output to disk