### PR TITLE
fix: replacing deprecated functions

### DIFF
--- a/controllers/rcj_soccer_player_b1/rcj_soccer_robot.py
+++ b/controllers/rcj_soccer_player_b1/rcj_soccer_robot.py
@@ -16,11 +16,11 @@ class RCJSoccerRobot:
         self.team = self.name[0]
         self.player_id = int(self.name[1])
 
-        self.receiver = self.robot.getReceiver("receiver")
+        self.receiver = self.robot.getDevice("receiver")
         self.receiver.enable(TIME_STEP)
 
-        self.left_motor = self.robot.getMotor("left wheel motor")
-        self.right_motor = self.robot.getMotor("right wheel motor")
+        self.left_motor = self.robot.getDevice("left wheel motor")
+        self.right_motor = self.robot.getDevice("right wheel motor")
 
         self.left_motor.setPosition(float('+inf'))
         self.right_motor.setPosition(float('+inf'))

--- a/controllers/rcj_soccer_player_y1/rcj_soccer_robot.py
+++ b/controllers/rcj_soccer_player_y1/rcj_soccer_robot.py
@@ -16,11 +16,11 @@ class RCJSoccerRobot:
         self.team = self.name[0]
         self.player_id = int(self.name[1])
 
-        self.receiver = self.robot.getReceiver("receiver")
+        self.receiver = self.robot.getDevice("receiver")
         self.receiver.enable(TIME_STEP)
 
-        self.left_motor = self.robot.getMotor("left wheel motor")
-        self.right_motor = self.robot.getMotor("right wheel motor")
+        self.left_motor = self.robot.getDevice("left wheel motor")
+        self.right_motor = self.robot.getDevice("right wheel motor")
 
         self.left_motor.setPosition(float('+inf'))
         self.right_motor.setPosition(float('+inf'))

--- a/controllers/rcj_soccer_referee_supervisor/referee/supervisor.py
+++ b/controllers/rcj_soccer_referee_supervisor/referee/supervisor.py
@@ -53,7 +53,7 @@ class RCJSoccerSupervisor(Supervisor):
         self.team_name_blue = team_name_blue
         self.team_name_yellow = team_name_yellow
 
-        self.emitter = self.getEmitter("emitter")
+        self.emitter = self.getDevice("emitter")
 
         self.robot_translation = ROBOT_INITIAL_TRANSLATION.copy()
         self.robot_rotation = ROBOT_INITIAL_ROTATION.copy()


### PR DESCRIPTION
Since Webots version 2021a the following functions are deprecated:
- getMotor
- getReceiver
- getEmitter

They can all be replaced with the function getDevice.

![webots_deprecated_warnings](https://user-images.githubusercontent.com/695073/104632012-5e7c7100-569d-11eb-97d6-84d4880fd058.PNG)