### PR TITLE
fix: make supervisor synchronous

### DIFF
--- a/scripts/templates/soccer.wbt.template
+++ b/scripts/templates/soccer.wbt.template
@@ -1150,6 +1150,6 @@ Robot {
     }
   ]
   controller "rcj_soccer_referee_supervisor"
-  synchronization FALSE
   supervisor TRUE
+  synchronization TRUE
 }

--- a/worlds/soccer.wbt
+++ b/worlds/soccer.wbt
@@ -1151,5 +1151,5 @@ Robot {
   ]
   controller "rcj_soccer_referee_supervisor"
   supervisor TRUE
-  synchronization FALSE
+  synchronization TRUE
 }


### PR DESCRIPTION
* this should fix the time to speed up when
  the simulator runs at maximum speed
* from docs: "for the robot competitions
  generally the Supervisor controller is
  synchronous while the contestants
  controllers are asynchronous"

Signed-off-by: Adrian Matejov <ado.matejov@gmail.com>