### PR TITLE
add: Emit `match_id` and `half_id` in `MATCH_START`

### DIFF
--- a/controllers/rcj_soccer_referee_supervisor/rcj_soccer_referee_supervisor.py
+++ b/controllers/rcj_soccer_referee_supervisor/rcj_soccer_referee_supervisor.py
@@ -53,8 +53,8 @@ TEAM_BLUE_ID = os.environ.get("RCJ_SIM_TEAM_BLUE_ID", "The Blues")
 BLUE_INITIAL_SCORE = os.environ.get("RCJ_SIM_TEAM_B_INITIAL_SCORE", "0")
 TEAM_BLUE_INITIAL_SCORE = int(BLUE_INITIAL_SCORE or "0")
 
-MATCH_ID = os.environ.get("RCJ_SIM_MATCH_ID", 1)
-HALF_ID = os.environ.get("RCJ_SIM_HALF_ID", 1)
+MATCH_ID = int(os.environ.get("RCJ_SIM_MATCH_ID", 1))
+HALF_ID = int(os.environ.get("RCJ_SIM_HALF_ID", 1))
 
 REC_FORMATS_RAW = os.environ.get("RCJ_SIM_REC_FORMATS", "").split(",")
 REC_FORMATS = [f for f in REC_FORMATS_RAW if f]
@@ -85,6 +85,8 @@ referee = RCJSoccerReferee(
     initial_score_yellow=TEAM_YELLOW_INITIAL_SCORE,
     penalty_area_allowed_time=15,
     penalty_area_reset_after=2,
+    match_id=MATCH_ID,
+    half_id=HALF_ID
 )
 
 recorders = []

--- a/controllers/rcj_soccer_referee_supervisor/referee/referee.py
+++ b/controllers/rcj_soccer_referee_supervisor/referee/referee.py
@@ -55,7 +55,8 @@ class RCJSoccerReferee(RCJSoccerSupervisor):
             self.progress_chck[robot].track(pos)
 
             x, z = pos[0], pos[2]
-            if is_outside(x, z) or not self.progress_chck[robot].is_progress(robot):
+            if (is_outside(x, z) or
+                    not self.progress_chck[robot].is_progress(robot)):
                 self.eventer.event(
                     supervisor=self,
                     type=GameEvents.LACK_OF_PROGRESS.value,
@@ -71,7 +72,7 @@ class RCJSoccerReferee(RCJSoccerSupervisor):
 
                 if nearest_spots:
                     neutral_spot = random.choice(
-                        nearest_spots[:LACK_OF_PROGRESS_NUMBER_OF_NEUTRAL_SPOTS],
+                        nearest_spots[:LACK_OF_PROGRESS_NUMBER_OF_NEUTRAL_SPOTS], # noqa
                     )
                     self.move_object_to_neutral_spot(robot, neutral_spot[0])
                     self.reset_checkers(robot)
@@ -79,7 +80,10 @@ class RCJSoccerReferee(RCJSoccerSupervisor):
         bpos = self.ball_translation.copy()
         self.progress_chck['ball'].track(bpos)
         bx, bz = bpos[0], bpos[2]
-        if is_outside(bx, bz) or not self.progress_chck['ball'].is_progress('ball'):
+
+        if (is_outside(bx, bz)
+                or not self.progress_chck['ball'].is_progress('ball')):
+
             self.eventer.event(
                 supervisor=self,
                 type=GameEvents.LACK_OF_PROGRESS.value,
@@ -94,7 +98,7 @@ class RCJSoccerReferee(RCJSoccerSupervisor):
 
             if nearest_spots:
                 neutral_spot = random.choice(
-                    nearest_spots[:LACK_OF_PROGRESS_NUMBER_OF_NEUTRAL_SPOTS],
+                    nearest_spots[:LACK_OF_PROGRESS_NUMBER_OF_NEUTRAL_SPOTS], # noqa
                 )
 
                 self.move_object_to_neutral_spot("ball", neutral_spot[0])
@@ -179,6 +183,8 @@ class RCJSoccerReferee(RCJSoccerSupervisor):
                     "total_match_time": self.match_time,
                     "team_name_yellow": self.team_name_yellow,
                     "team_name_blue": self.team_name_blue,
+                    "match_id": self.match_id,
+                    "halftime": self.half_id,
                 },
             )
 
@@ -223,8 +229,8 @@ class RCJSoccerReferee(RCJSoccerSupervisor):
                 self.kickoff(self.team_to_kickoff)
 
         # WORKAROUND: The proper way of moving the ball is to set its position
-        # and call resetPhysics on the ball. However, the ball has small velocity
-        # and is moving a bit.
+        # and call resetPhysics on the ball. However, the ball has small
+        # velocity and is moving a bit.
         # See https://github.com/cyberbotics/webots/issues/2899
         if self.ball_stop > 0:
             if self.ball_stop == 1:

--- a/controllers/rcj_soccer_referee_supervisor/referee/supervisor.py
+++ b/controllers/rcj_soccer_referee_supervisor/referee/supervisor.py
@@ -18,7 +18,6 @@ from referee.consts import (
     NEUTRAL_SPOTS,
     NeutralSpotDistanceType,
     DISTANCE_AROUND_UNOCCUPIED_NEUTRAL_SPOT,
-    Team,
     OBJECT_DEPTH,
     BALL_DEPTH,
 )
@@ -31,6 +30,8 @@ class RCJSoccerSupervisor(Supervisor):
     def __init__(
         self,
         match_time: int,
+        match_id: int,
+        half_id: int,
         progress_check_steps: int,
         progress_check_threshold: int,
         ball_progress_check_steps: int,
@@ -48,6 +49,8 @@ class RCJSoccerSupervisor(Supervisor):
         super().__init__()
 
         self.match_time = match_time
+        self.match_id = match_id
+        self.half_id = half_id
         self.post_goal_wait_time = post_goal_wait_time
         self.initial_position_noise = initial_position_noise
 
@@ -538,4 +541,5 @@ class RCJSoccerSupervisor(Supervisor):
             self.set_ball_position([x, BALL_DEPTH, z])
         else:
             self.set_robot_position(object_name, [x, OBJECT_DEPTH, z])
-            self.set_robot_rotation(object_name, ROBOT_INITIAL_ROTATION[object_name])
+            self.set_robot_rotation(object_name,
+                                    ROBOT_INITIAL_ROTATION[object_name])


### PR DESCRIPTION
* Ensure the `reflog` has information on what half of the match is being
  played in the particular reflog.

Signed-off-by: mr.Shu <mr@shu.io>