### PR TITLE
Split Referee and Supervisor

### DIFF
--- a/controllers/rcj_soccer_referee_supervisor/referee/event_handlers.py
+++ b/controllers/rcj_soccer_referee_supervisor/referee/event_handlers.py
@@ -10,15 +10,14 @@ class EventHandler:
 
     def handle(
         self,
-        supervisor,  # Supervisor from supervisor.py
+        referee,  # Referee from referee.py
         type: str,
         payload: Optional[dict] = None,
     ):
         """Handle the incoming event
 
         Args:
-            supervisor (Supervisor): Instance of Referee, which is in turn
-                instance of supervisor
+            referee (RCJSoccerReferee): Instance of Referee
             type (str): Event type
             payload (dict, optional): More information about the event
         """
@@ -32,8 +31,8 @@ class JSONLoggerHandler(EventHandler):
         super().__init__()
         self.logfile = logfile
 
-    def handle(self, supervisor, type: str, payload: Optional[dict] = None):
-        matchtime = supervisor.match_time - supervisor.time
+    def handle(self, referee, type: str, payload: Optional[dict] = None):
+        matchtime = referee.match_time - referee.time
         data = {
             "datetime": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "matchtime": matchtime,
@@ -80,9 +79,9 @@ class DrawMessageHandler(EventHandler):
     def create_match_finish_msg(self, total_match_time: int, **kwargs) -> str:
         return f"The match time {total_match_time}s is over."
 
-    def handle(self, supervisor, type: str, payload: Optional[dict] = None):
+    def handle(self, referee, type: str, payload: Optional[dict] = None):
         # Call formatter based on event type.
         msg_formatter = getattr(self, f"create_{type.lower()}_msg")
         data = payload if payload is not None else {}
         message = msg_formatter(**data)
-        supervisor.add_event_message_to_queue(message)
+        referee.add_event_message_to_queue(message)

--- a/controllers/rcj_soccer_referee_supervisor/referee/penalty_area_checker.py
+++ b/controllers/rcj_soccer_referee_supervisor/referee/penalty_area_checker.py
@@ -17,10 +17,10 @@ class PenaltyAreaChecker:
         self.time_entered_penalty = None
         self.time_left_penalty = None
 
-    def is_in_yellow_penalty(self, x: int, z: int) -> bool:
+    def is_in_yellow_penalty(self, x: float, z: float) -> bool:
         return x < self.y_vertical and self.y_lower < z < self.y_upper
 
-    def is_in_blue_penalty(self, x: int, z: int) -> bool:
+    def is_in_blue_penalty(self, x: float, z: float) -> bool:
         return x > self.b_vertical and self.b_lower < z < self.b_upper
 
     @property
@@ -40,6 +40,12 @@ class PenaltyAreaChecker:
         return self.time_left_penalty is not None
 
     def track(self, position: List[float], time: int):
+        """Make PenaltyAreaChecker react to a new position.
+
+        Args:
+            position (list): Current position of the object
+            time (int): Current game time
+        """
         self.time = time
         x, z = position[0], position[2]
 
@@ -58,13 +64,12 @@ class PenaltyAreaChecker:
             elif self.has_left and self.has_been_outside_penalty_for_longer:
                 self.reset()
 
-    def is_violating(self) -> int:
-        """
-        Detect whether the robot stays for longer period of time inside
+    def is_violating(self) -> bool:
+        """Detect whether the robot stays for longer period of time inside
         the penalty area.
 
         Returns:
-            bool - whether the robot is violating this rule
+            bool: whether the robot is violating this rule
         """
         if self.has_entered and not self.has_left:
             if self.is_inside_penalty_over_limit:

--- a/controllers/rcj_soccer_referee_supervisor/referee/progress_checker.py
+++ b/controllers/rcj_soccer_referee_supervisor/referee/progress_checker.py
@@ -1,4 +1,5 @@
 import math
+from typing import List
 
 
 class ProgressChecker:
@@ -13,12 +14,14 @@ class ProgressChecker:
         self.iterator = 0
         self.prev_position = None
 
-    def track(self, position):
-        """
-        Make ProgressChecker react to a new position. Internally, it computes
+    def track(self, position: List[float]):
+        """Make ProgressChecker react to a new position. Internally, it computes
         the Euclidian distance from the previous position and saves it so that
         it can be used when computing whether the given object has made
         progress.
+
+        Args:
+            position (list): Current position of the object
         """
         # If the track function gets called for the first time (i.e. we do not
         # remember the previous position), store the current position as the
@@ -40,23 +43,15 @@ class ProgressChecker:
 
         self.prev_position = position
 
-    def is_progress(self, robot=None) -> bool:
-        """
-        Detect whether the object which is being tracked has made some
+    def is_progress(self) -> bool:
+        """Detect whether the object which is being tracked has made some
         "progress". In other words, check whether we have tracked enough
         movement (more than the threshold) since the last reset.
 
-        Args:
-            robot (optional): name of robot, used only for debugging purposes.
+        Returns:
+            bool: Whether the object has made some "progress"
         """
         s = sum(self.samples)
-
-        # if robot:
-        #     print(f'Robot {robot} iterator: {self.iterator}, '
-        #           f's: {s}, thr: {self.threshold}')
-        # else:
-        #     print(f'iterator: {self.iterator}, s: {s}, '
-        #           f'thr: {self.threshold}')
 
         # We we haven't tracked at least as many samples as the number of
         # steps, our default position is "benefit of doubt": we assume enough

--- a/controllers/rcj_soccer_referee_supervisor/referee/supervisor.py
+++ b/controllers/rcj_soccer_referee_supervisor/referee/supervisor.py
@@ -1,130 +1,50 @@
 import math
-import random
-import struct
 from typing import List, Tuple
 
 from controller import Supervisor
 
 from referee.consts import (
     BALL_DEPTH,
-    BALL_INITIAL_TRANSLATION,
     DISTANCE_AROUND_UNOCCUPIED_NEUTRAL_SPOT,
-    KICKOFF_TRANSLATION,
     LabelIDs,
-    MAX_EVENT_MESSAGES_IN_QUEUE,
     NEUTRAL_SPOTS,
     NeutralSpotDistanceType,
     OBJECT_DEPTH,
     ROBOT_INITIAL_ROTATION,
-    ROBOT_INITIAL_TRANSLATION,
     ROBOT_NAMES,
 )
-from referee.event_handlers import EventHandler
-from referee.eventer import Eventer
-from referee.penalty_area_checker import PenaltyAreaChecker
-from referee.progress_checker import ProgressChecker
 from referee.utils import time_to_string
 
 
 class RCJSoccerSupervisor(Supervisor):
-    def __init__(
-        self,
-        match_time: int,
-        match_id: int,
-        half_id: int,
-        progress_check_steps: int,
-        progress_check_threshold: int,
-        ball_progress_check_steps: int,
-        ball_progress_check_threshold: int,
-        team_name_blue: str,
-        team_name_yellow: str,
-        initial_score_blue: int,
-        initial_score_yellow: int,
-        penalty_area_allowed_time: int,
-        penalty_area_reset_after: int,
-        post_goal_wait_time: int = 3,
-        initial_position_noise: float = 0.15,
-    ):
-
+    def __init__(self):
         super().__init__()
-
-        self.match_time = match_time
-        self.match_id = match_id
-        self.half_id = half_id
-        self.post_goal_wait_time = post_goal_wait_time
-        self.initial_position_noise = initial_position_noise
-
-        self.time = match_time
-
-        # Event message queue to be drawn
-        # List of Tuples of int (time) and string (message)
-        self.event_messages_to_draw: List[Tuple[int, str]] = []
-
-        self.eventer = Eventer()
-
-        self.team_name_blue = team_name_blue
-        self.team_name_yellow = team_name_yellow
 
         self.emitter = self.getDevice("emitter")
 
-        self.ball_stop = 2
-
-        self.robot_translation = ROBOT_INITIAL_TRANSLATION.copy()
-        self.robot_rotation = ROBOT_INITIAL_ROTATION.copy()
+        self.ball = self.getFromDef("BALL")
+        self.ball_translation_field = self.ball.getField("translation")
+        self.ball_translation = self.ball_translation_field.getSFVec3f()
 
         self.robot_nodes = {}
         self.robot_translation_fields = {}
         self.robot_rotation_fields = {}
-
-        self.robot_in_penalty_counter = {}
-
-        self.progress_chck = {}
-        self.penalty_area_chck = {}
-
+        self.robot_translation = {}
+        self.robot_rotation = {}
         for robot in ROBOT_NAMES:
             robot_node = self.getFromDef(robot)
             self.robot_nodes[robot] = robot_node
-            field = robot_node.getField("translation")
 
+            field = robot_node.getField("translation")
             self.robot_translation_fields[robot] = field
+            self.robot_translation[robot] = field.getSFVec3f()
 
             field = robot_node.getField("rotation")
             self.robot_rotation_fields[robot] = field
-
-            self.robot_in_penalty_counter[robot] = 0
-
-            self.progress_chck[robot] = ProgressChecker(
-                progress_check_steps, progress_check_threshold
-            )
-
-            self.penalty_area_chck[robot] = PenaltyAreaChecker(
-                penalty_area_allowed_time,
-                penalty_area_reset_after,
-            )
-
-        self.ball = self.getFromDef("BALL")
-        self.ball_translation_field = self.ball.getField("translation")
-
-        bpc = ProgressChecker(
-            ball_progress_check_steps, ball_progress_check_threshold
-        )
-        self.progress_chck["ball"] = bpc
-
-        self.reset_positions()
-
-        self.update_positions()
-
-        self.ball_reset_timer = 0
-
-        self.score_blue = initial_score_blue
-        self.score_yellow = initial_score_yellow
-        # The team that ought to have the kickoff at the next restart
-        self.team_to_kickoff = None
-
-        self.draw_team_names()
-        self.draw_scores(self.score_blue, self.score_yellow)
+            self.robot_rotation[robot] = field.getSFRotation()
 
     def update_positions(self):
+        """Update the positions of robots and the ball"""
         self.ball_translation = self.ball_translation_field.getSFVec3f()
 
         for robot in ROBOT_NAMES:
@@ -134,182 +54,26 @@ class RCJSoccerSupervisor(Supervisor):
             r = self.robot_rotation_fields[robot].getSFRotation()
             self.robot_rotation[robot] = r
 
-            # TODO: update self.robot_in_penalty_counter if the robot
-            #       is located in penalty area
-
         assert len(self.robot_translation) == len(self.robot_rotation)
 
-    def add_event_subscriber(self, subscriber: EventHandler):
-        """Add new event subscriber.
+    def get_robot_translation(self, robot: str) -> list:
+        """Return the position of the robot.
 
         Args:
-            subscriber (EventHandler): Instance inheriting EventHandler
-        """
-        self.eventer.subscribe(subscriber)
-
-    def draw_team_names(self):
-        """Visualize (draw) the names of the teams."""
-
-        self.setLabel(
-            LabelIDs.BLUE_TEAM.value,
-            self.team_name_blue,
-            0.92 - (len(self.team_name_blue) * 0.01),  # X position
-            0.05,  # Y position
-            0.1,  # Size
-            0x0000FF,  # Color
-            0.0,  # Transparency
-            "Tahoma",  # Font
-        )
-
-        self.setLabel(
-            LabelIDs.YELLOW_TEAM.value,
-            self.team_name_yellow,
-            0.05,  # X position
-            0.05,  # Y position
-            0.1,  # Size
-            0xFFFF00,  # Color
-            0.0,  # Transparency
-            "Tahoma",  # Font
-        )
-
-    def draw_scores(self, blue: int, yellow: int):
-        """Visualize (draw) the provide scores for both the blue and
-        the yellow teams.
-
-        Args:
-            blue (int): score of the blue team
-            yellow (int): score of the yellow team
-        """
-
-        self.setLabel(
-            LabelIDs.BLUE_SCORE.value,
-            str(blue),
-            0.92,  # X position
-            0.01,  # Y position
-            0.1,  # Size
-            0x0000FF,  # Color
-            0.0,  # Transparency
-            "Tahoma",  # Font
-        )
-
-        self.setLabel(
-            LabelIDs.YELLOW_SCORE.value,
-            str(yellow),
-            0.05,  # X position
-            0.01,  # Y position
-            0.1,  # Size
-            0xFFFF00,  # Color
-            0.0,  # Transparency
-            "Tahoma",  # Font
-        )
-
-    def draw_time(self, time: int):
-        """Visualize (draw) the current match time
-
-        Args:
-            time (int): the current match time
-        """
-
-        self.setLabel(
-            LabelIDs.TIME.value,
-            time_to_string(time),
-            0.45,
-            0.01,
-            0.1,
-            0x000000,
-            0.0,
-            "Arial",
-        )
-
-    def draw_goal_sign(self, transparency: float = 0.0):
-        """Visualize (draw) a GOAL! sign after goal gets scored.
-
-        Args:
-
-            transparency (float): the transparecny of the text, with 0 meaning
-                no transparency and 1 meaning total transparency (the text will
-                not be visible).
-        """
-
-        self.setLabel(
-            LabelIDs.GOAL.value,
-            "GOAL!",
-            0.30,
-            0.40,
-            0.4,
-            0xFF0000,
-            transparency,
-            "Verdana",
-        )
-
-    def hide_goal_sign(self):
-        """Hide the GOAL! once the game is again in progress."""
-
-        self.setLabel(
-            LabelIDs.GOAL.value,
-            "",
-            0.30,
-            0.40,
-            0.4,
-            0xFF0000,
-            1.0,
-            "Verdana",
-        )
-
-    def draw_event_messages(self):
-        """Visualize (draw) the event messages from queue"""
-        messages = []
-        for time, msg in self.event_messages_to_draw:
-            messages.append("{} - {}".format(time_to_string(time), msg))
-
-        if messages:
-            self.setLabel(
-                LabelIDs.EVENT_MESSAGES.value,
-                "\n".join(messages),
-                0.01,
-                0.95 - ((len(messages) - 1) * 0.025),
-                0.05,
-                0xFFFFFF,
-                0.0,
-                "Tahoma",
-            )
-
-    def add_event_message_to_queue(self, message: str):
-        if len(self.event_messages_to_draw) >= MAX_EVENT_MESSAGES_IN_QUEUE:
-            self.event_messages_to_draw.pop(0)
-
-        self.event_messages_to_draw.append((self.time, message))
-
-    def _pack_packet(self):
-        """Pack data into packet.
+            robot (str): The robot whose position is returned
 
         Returns:
-            str: the packed packet.
+            list: x, y and z coordinates
         """
-        # True/False telling whether the goal was scored
-        struct_fmt = "?"
-        data = list()
+        return self.robot_translation[robot]
 
-        # Add Notification if the goal is scored and we are waiting for kickoff
-        # The value is True or False
-        data.append(self.ball_reset_timer > 0)
+    def get_ball_translation(self) -> list:
+        """Return the position of the ball.
 
-        return struct.pack(struct_fmt, *data)
-
-    def emit_data(self):
-        packet = self._pack_packet()
-        self.emitter.send(packet)
-
-    def reset_positions(self):
+        Returns:
+            list: x, y and z coordinates
         """
-        Reset the positions of the ball as well as the robots to the initial
-        position.
-        """
-        self.reset_ball_position()
-
-        # reset the robot positions
-        for robot in ROBOT_NAMES:
-            self.reset_robot_position(robot)
+        return self.ball_translation
 
     def set_robot_position(self, robot_name: str, position: List[float]):
         """Set the position of a robot.
@@ -332,30 +96,7 @@ class RCJSoccerSupervisor(Supervisor):
         """
         rot_field = self.robot_rotation_fields[robot_name]
         rot_field.setSFRotation(rotation)
-
-    def reset_robot_position(self, robot_name: str):
-        """Reset robot's position to the initial one.
-
-        Args:
-            robot_name (str): The robot to reset the position for
-        """
-        self.reset_robot_velocity(robot_name)
-
-        translation = ROBOT_INITIAL_TRANSLATION[robot_name].copy()
-        translation = self._add_initial_position_noise(translation)
-
-        self.set_robot_position(robot_name, translation)
-        self.set_robot_rotation(robot_name, ROBOT_INITIAL_ROTATION[robot_name])
-
-        self.reset_checkers(robot_name)
-
-    def reset_robot_velocity(self, robot_name: str):
-        """Reset the robot's velocity.
-
-        Args:
-            robot_name (str): The robot we set the velocity for
-        """
-        self.getFromDef(robot_name).setVelocity([0, 0, 0, 0, 0, 0])
+        self.robot_rotation[robot_name] = rotation
 
     def set_ball_position(self, position: List[float]):
         """Set the position of the ball.
@@ -363,64 +104,22 @@ class RCJSoccerSupervisor(Supervisor):
         Args:
             position (list of floats): The actual position
         """
-        ball_translation_field = self.ball.getField("translation")
-        ball_translation_field.setSFVec3f(position)
+        self.ball_translation_field.setSFVec3f(position)
         self.reset_ball_velocity()
-        self.ball_stop = 2
         self.ball.resetPhysics()
         self.ball_translation = position
+
+    def reset_robot_velocity(self, robot_name: str):
+        """Reset the robot's velocity.
+
+        Args:
+            robot_name (str): The robot we set the velocity for
+        """
+        self.robot_nodes[robot_name].setVelocity([0, 0, 0, 0, 0, 0])
 
     def reset_ball_velocity(self):
         """Reset the ball's velocity."""
         self.ball.setVelocity([0, 0, 0, 0, 0, 0])
-
-    def reset_ball_position(self):
-        """Reset the position of the ball."""
-        self.set_ball_position(BALL_INITIAL_TRANSLATION)
-        self.progress_chck["ball"].reset()
-
-    def _add_initial_position_noise(
-        self, translation: List[float]
-    ) -> List[float]:
-
-        level = self.initial_position_noise
-        translation[0] += (random.random() - 0.5) * level
-        translation[2] += (random.random() - 0.5) * level
-        return translation
-
-    def reset_checkers(self, object_name: str):
-        """Reset rule checkers for the specified object.
-
-        Args:
-            object_name (str): Either "ball" or the robot's name.
-        """
-        self.progress_chck[object_name].reset()
-        if object_name != "ball":
-            self.penalty_area_chck[object_name].reset()
-
-    def robot_name_to_team_name(self, robot_name: str) -> str:
-        if robot_name.startswith("Y"):
-            return self.team_name_yellow
-        elif robot_name.startswith("B"):
-            return self.team_name_blue
-        else:
-            raise ValueError(f"Unrecognized robot's name {robot_name}")
-
-    def reset_team_for_kickoff(self, team: str):
-        """
-        Given a team name ('B' or 'Y'), set the position of the third robot on
-        the team to "kick off" (inside the center circle).
-
-        Returns:
-            str: Name of the robot that is kicking off.
-        """
-        # Always kickoff with the third robot
-        robot = f"{team}3"
-
-        self.set_robot_position(robot, KICKOFF_TRANSLATION[team])
-        self.set_robot_rotation(robot, ROBOT_INITIAL_ROTATION[robot])
-
-        return robot
 
     def is_neutral_spot_occupied(self, ns_x: float, ns_z: float) -> bool:
         """Check whether the specific neutral spot is occupied
@@ -490,11 +189,7 @@ class RCJSoccerSupervisor(Supervisor):
 
         return sorted_pairs
 
-    def move_object_to_neutral_spot(
-        self,
-        object_name: str,
-        neutral_spot: str,
-    ):
+    def move_object_to_neutral_spot(self, object_name: str, neutral_spot: str):
         """Move the robot to the specified neutral spot.
 
         Args:
@@ -502,7 +197,6 @@ class RCJSoccerSupervisor(Supervisor):
             neutral_spot (str): The spot the robot will be moved to
         """
         x, z = NEUTRAL_SPOTS[neutral_spot]
-
         if object_name == "ball":
             self.set_ball_position([x, BALL_DEPTH, z])
         else:
@@ -510,3 +204,137 @@ class RCJSoccerSupervisor(Supervisor):
             self.set_robot_rotation(
                 object_name, ROBOT_INITIAL_ROTATION[object_name]
             )
+
+    def emit_data(self, packet: bytes):
+        """Send packet via emitter
+
+        Args:
+            packet (bytes): the packet to be sent
+        """
+        self.emitter.send(packet)
+
+    def draw_team_names(self, team_name_blue: str, team_name_yellow: str):
+        """Visualize (draw) the names of the teams.
+
+        Args:
+            team_name_blue (str): name of the blue team
+            team_name_yellow (str): name of the yellow team
+        """
+        self.setLabel(
+            LabelIDs.BLUE_TEAM.value,
+            team_name_blue,
+            0.92 - (len(team_name_blue) * 0.01),  # X position
+            0.05,  # Y position
+            0.1,  # Size
+            0x0000FF,  # Color
+            0.0,  # Transparency
+            "Tahoma",  # Font
+        )
+
+        self.setLabel(
+            LabelIDs.YELLOW_TEAM.value,
+            team_name_yellow,
+            0.05,  # X position
+            0.05,  # Y position
+            0.1,  # Size
+            0xFFFF00,  # Color
+            0.0,  # Transparency
+            "Tahoma",  # Font
+        )
+
+    def draw_scores(self, blue: int, yellow: int):
+        """Visualize (draw) the provide scores for both the blue and
+        the yellow teams.
+
+        Args:
+            blue (int): score of the blue team
+            yellow (int): score of the yellow team
+        """
+        self.setLabel(
+            LabelIDs.BLUE_SCORE.value,
+            str(blue),
+            0.92,  # X position
+            0.01,  # Y position
+            0.1,  # Size
+            0x0000FF,  # Color
+            0.0,  # Transparency
+            "Tahoma",  # Font
+        )
+
+        self.setLabel(
+            LabelIDs.YELLOW_SCORE.value,
+            str(yellow),
+            0.05,  # X position
+            0.01,  # Y position
+            0.1,  # Size
+            0xFFFF00,  # Color
+            0.0,  # Transparency
+            "Tahoma",  # Font
+        )
+
+    def draw_time(self, time: int):
+        """Visualize (draw) the current match time
+
+        Args:
+            time (int): the current match time
+        """
+        self.setLabel(
+            LabelIDs.TIME.value,
+            time_to_string(time),
+            0.45,
+            0.01,
+            0.1,
+            0x000000,
+            0.0,
+            "Arial",
+        )
+
+    def draw_event_messages(self, messages: List[str]):
+        """Visualize (draw) the event messages from queue
+
+        Args:
+            messages: List of string messages to be drawn
+        """
+        if messages:
+            self.setLabel(
+                LabelIDs.EVENT_MESSAGES.value,
+                "\n".join(messages),
+                0.01,
+                0.95 - ((len(messages) - 1) * 0.025),
+                0.05,
+                0xFFFFFF,
+                0.0,
+                "Tahoma",
+            )
+
+    def draw_goal_sign(self, transparency: float = 0.0):
+        """Visualize (draw) a GOAL! sign after goal gets scored.
+
+        Args:
+            transparency (float): the transparecny of the text, with 0 meaning
+                no transparency and 1 meaning total transparency (the text will
+                not be visible).
+        """
+        self.setLabel(
+            LabelIDs.GOAL.value,
+            "GOAL!",
+            0.30,
+            0.40,
+            0.4,
+            0xFF0000,
+            transparency,
+            "Verdana",
+        )
+
+    def hide_goal_sign(self):
+        """Hide the GOAL! once the game is again in progress."""
+        self.setLabel(
+            LabelIDs.GOAL.value,
+            "",
+            0.30,
+            0.40,
+            0.4,
+            0xFF0000,
+            1.0,
+            "Verdana",
+        )


### PR DESCRIPTION
* Supervisor takes care only about tracking positions of objects,
  provides them to referee, draws text onto the surface, records
  video, emits packets and provides some helper functions for
  computing unoccupied neutral spots
* Referee counts the time and the score and implements the rules.
* Move Eventer from Supervisor to Referee
* closes #118

Signed-off-by: Adrian Matejov <ado.matejov@gmail.com>